### PR TITLE
Build czalloc in appropriate optimization mode for test cases

### DIFF
--- a/build/create.zig
+++ b/build/create.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+pub const LibOptions = struct {
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    linkage: std.builtin.LinkMode,
+    use_lld: bool,
+    use_llvm: bool,
+    pie: bool,
+    want_lto: bool,
+    strip: bool,
+};
+
+pub fn lib(b: *std.Build, options: LibOptions) struct { *std.Build.Module, *std.Build.Step.Compile } {
+    const lib_mod = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = options.target,
+        .optimize = options.optimize,
+        .link_libc = true,
+        .sanitize_c = .full,
+        .stack_check = true,
+        .strip = options.strip,
+    });
+
+    const lib_comp = b.addLibrary(.{
+        .name = "czalloc",
+        .linkage = options.linkage,
+        .root_module = lib_mod,
+        .use_lld = options.use_lld,
+        .use_llvm = options.use_llvm,
+    });
+    lib_comp.pie = options.use_llvm;
+    lib_comp.want_lto = options.want_lto;
+
+    return .{ lib_mod, lib_comp };
+}


### PR DESCRIPTION
The global `options` for std is `std_options` not `options` fix that

move module and compile artifact creating to build/create.zig

refactor CaseOptions to use LibOptions

Setup different allocators for different optimization modes in czalloc .ie fba for .ReleaseSmall
    da for .ReleaseSafe and .Debug
    smpa for .ReleasaeFast

Add null enumeration to Pointer type and assert alloc_ptr isn't .null

don't run leak checks in non-debug modes